### PR TITLE
Proposed change for a new logging level, that specifies do not log anything

### DIFF
--- a/src/main/clojure/clojure/tools/logging/impl.clj
+++ b/src/main/clojure/clojure/tools/logging/impl.clj
@@ -45,6 +45,7 @@
           {:enabled?
            (fn [logger# level#]
              (condp = level#
+               :noop  false
                :trace (.isTraceEnabled logger#)
                :debug (.isDebugEnabled logger#)
                :info  (.isInfoEnabled  logger#)
@@ -92,6 +93,7 @@
            {:enabled?
             (fn [logger# level#]
               (condp = level#
+                :noop false
                 :trace (.isTraceEnabled logger#)
                 :debug (.isDebugEnabled logger#)
                 :info  (.isInfoEnabled  logger#)
@@ -142,15 +144,16 @@
            Logger
            {:enabled?
             (fn [logger# level#]
-              (.isEnabledFor logger#
-                 (or
-                   (levels# level#)
-                   (throw (IllegalArgumentException. (str level#))))))
+              (and (not (= :noop level#)) 
+                   (.isEnabledFor logger#
+                     (or
+                       (levels# level#)
+                       (throw (IllegalArgumentException. (str  level#)))))))
             :write!
             (fn [logger# level# e# msg#]
               (let [level# (or
                              (levels# level#)
-                             (throw (IllegalArgumentException. (str level#))))]
+                             (throw (IllegalArgumentException. (str  level#))))]
                 (if e#
                   (.log logger# level# msg# e#)
                   (.log logger# level# msg#))))})


### PR DESCRIPTION
Motivation:  When using the log macro, the user specifies a logging level, which is a keyword.
I would like to have the ability to specify the logging level by executing a function, which will return the logging level I would like to use.  The use case being a system where logging can be dynamically reconfigured, turned off/on/etc.  Currently the only missing piece is that there is no legal logging level which means "don't log anything".  

This pull request proposes that a new logging level of :noop be defined, which means, do not log anything

Changes are proposed to correctly handle the new logging level.

I have a signed CA on file.  

Don Jackson
