### PR TITLE
Return nil from log* regardless of mode

### DIFF
--- a/src/main/clojure/clojure/tools/logging.clj
+++ b/src/main/clojure/clojure/tools/logging.clj
@@ -47,7 +47,8 @@
   failed transactions though at the cost of repeat messages during retries.
 
   One can override the above by setting *force* to :direct or :agent; all
-  subsequent writes will be direct or via an agent, respectively."
+  subsequent writes will be direct or via an agent, respectively.
+  Returns nil."
   [logger level throwable message]
   (if (cond
         (nil? *force*) (and (clojure.lang.LockingTransaction/isRunning)
@@ -56,7 +57,8 @@
         (= *force* :direct) false)
     (send-off *logging-agent*
       (fn [_#] (impl/write! logger level throwable message)))
-    (impl/write! logger level throwable message)))
+    (impl/write! logger level throwable message))
+  nil)
 
 (declare ^{:dynamic true} *logger-factory*) ; default LoggerFactory instance for calling impl/get-logger
 

--- a/src/test/clojure/clojure/tools/test_logging.clj
+++ b/src/test/clojure/clojure/tools/test_logging.clj
@@ -34,6 +34,12 @@
     (f)
     (swap! *entries* (constantly []))))
 
+(deftest nil-return-regardless-of-mode
+  (binding [*force* :direct]
+    (is (nil? (log :debug "direct"))))
+  (binding [*force* :agent]
+    (is (nil? (log :debug "agent")))))
+
 (deftest log-single-eval
   (let [cnt (atom 0)]
     (log :debug (swap! cnt inc))


### PR DESCRIPTION
The differing (and undocumented) return values from log\* depending on _force_ or implementation can have undesired effects on client code.  One could argue that the client code should guard against the return value of the log functions.  However, having the return value of log\* be consistent will allow for more performant and cleaner code.

Signed-off-by: Chris Hapgood cch1@hapgoods.com
